### PR TITLE
workflows: build: Add arm runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
macOS is arm-only so that's good already