### PR TITLE
cli: programfile: Warn when receiving a 0-length image

### DIFF
--- a/cli/src/programfile.rs
+++ b/cli/src/programfile.rs
@@ -121,9 +121,7 @@ fn parse_program_cmd<T: Read + Write + QdlChan>(
 
     let label = attrs.get("label").unwrap();
     if num_sectors == 0 {
-        if verbose {
-            println!("Skipping 0-length entry for {}", label);
-        }
+        println!("Skipping 0-length entry for {}", label);
         return Ok(());
     }
     if BOOTABLE_PART_NAMES.contains(&&label[..]) {


### PR DESCRIPTION
Certain tools happily tell us that an image is 0 sectors long.. which is not particularly cool of them.