### PR TITLE
treewide: Fixes for uninlined_format_args (clippy update)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -237,7 +237,7 @@ fn main() -> Result<()> {
         args.verbose_sahara,
     )?;
     let sn = u32::from_le_bytes([sn[0], sn[1], sn[2], sn[3]]);
-    println!("Chip serial number: 0x{:x}", sn);
+    println!("Chip serial number: 0x{sn:x}");
 
     let key_hash = sahara_run(
         &mut qdl_dev,

--- a/cli/src/programfile.rs
+++ b/cli/src/programfile.rs
@@ -57,10 +57,7 @@ fn parse_patch_cmd<T: Read + Write + QdlChan>(
 ) -> anyhow::Result<()> {
     if let Some(filename) = attrs.get("filename") {
         if filename != "DISK" && verbose {
-            println!(
-                "Skipping <patch> tag trying to alter {} on Host filesystem",
-                filename
-            );
+            println!("Skipping <patch> tag trying to alter {filename} on Host filesystem");
             return Ok(());
         }
     } else {
@@ -121,7 +118,7 @@ fn parse_program_cmd<T: Read + Write + QdlChan>(
 
     let label = attrs.get("label").unwrap();
     if num_sectors == 0 {
-        println!("Skipping 0-length entry for {}", label);
+        println!("Skipping 0-length entry for {label}");
         return Ok(());
     }
     if BOOTABLE_PART_NAMES.contains(&&label[..]) {
@@ -133,7 +130,7 @@ fn parse_program_cmd<T: Read + Write + QdlChan>(
     if allow_missing_files {
         if filename.is_empty() {
             if verbose {
-                println!("Skipping bogus entry for {}", label);
+                println!("Skipping bogus entry for {label}");
             }
             return Ok(());
         } else if !file_path.exists() {

--- a/qdl/src/lib.rs
+++ b/qdl/src/lib.rs
@@ -130,7 +130,7 @@ pub fn firehose_read<T: Read + Write + QdlChan>(
             // DEBUG: "print out incoming packets"
             // TODO: define a more verbose level
             if channel.fh_config().verbose_firehose {
-                println!("RECV: {}", format!("{:?}", e).magenta());
+                println!("RECV: {}", format!("{e:?}").magenta());
             }
 
             // TODO: Use std::intrinsics::unlikely after it exits nightly
@@ -181,7 +181,7 @@ pub fn firehose_write_getack<T: Read + Write + QdlChan>(
         Ok(FirehoseStatus::Nak) => {
             // Assume FH will hang after NAK..
             firehose_reset(channel, &FirehoseResetMode::ResetToEdl, 0)?;
-            Err(anyhow::Error::msg(format!("Couldn't {}", couldnt_what)))
+            Err(anyhow::Error::msg(format!("Couldn't {couldnt_what}")))
         }
         Err(e) => Err(e),
     }
@@ -320,7 +320,7 @@ pub fn firehose_peek<T: Read + Write + QdlChan>(
         ],
     )?;
 
-    firehose_write_getack(channel, &mut xml, format!("peek @ {:#x}", addr))
+    firehose_write_getack(channel, &mut xml, format!("peek @ {addr:#x}"))
 }
 
 /// Poke at memory
@@ -342,7 +342,7 @@ pub fn firehose_poke<T: Read + Write + QdlChan>(
         ],
     )?;
 
-    firehose_write_getack(channel, &mut xml, format!("peek @ {:#x}", addr))
+    firehose_write_getack(channel, &mut xml, format!("peek @ {addr:#x}"))
 }
 
 /// Write to Device storage
@@ -380,7 +380,7 @@ pub fn firehose_program_storage<T: Read + Write + QdlChan>(
 
     let mut pb = ProgressBar::new((sectors_left * channel.fh_config().storage_sector_size) as u64);
     pb.show_time_left = true;
-    pb.message(&format!("Sending partition {}: ", label));
+    pb.message(&format!("Sending partition {label}: "));
     pb.set_units(Units::Bytes);
 
     while sectors_left > 0 {
@@ -558,7 +558,7 @@ pub fn firehose_set_bootable<T: Read + Write + QdlChan>(
     firehose_write_getack(
         channel,
         &mut xml,
-        format!("set partition {} as bootable", drive_idx),
+        format!("set partition {drive_idx} as bootable"),
     )
 }
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args