### PR TITLE
cli/qdl: Handle multiple storage slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Options:
           Work around missing HELLO packet
   -s, --storage-type <emmc/ufs/nvme/nand>
 
+  -S, --storage-slot <STORAGE_SLOT>
+          Index of the physical device (e.g. 1 for secondary UFS) [default: 0]
       --sector-size <SECTOR_SIZE>
 
       --skip-storage-init

--- a/cli/src/programfile.rs
+++ b/cli/src/programfile.rs
@@ -25,6 +25,7 @@ fn parse_read_cmd<T: Read + Write + QdlChan>(
         .unwrap()
         .parse::<usize>()
         .unwrap();
+    let slot = attrs.get("slot").map_or(0, |a| a.parse::<u8>().unwrap());
     let phys_part_idx = attrs
         .get("physical_partition_number")
         .unwrap()
@@ -45,6 +46,7 @@ fn parse_read_cmd<T: Read + Write + QdlChan>(
         channel,
         &mut outfile,
         num_sectors,
+        slot,
         phys_part_idx,
         start_sector,
     )
@@ -65,6 +67,7 @@ fn parse_patch_cmd<T: Read + Write + QdlChan>(
     }
 
     let byte_off = attrs.get("byte_offset").unwrap().parse::<u64>().unwrap();
+    let slot = attrs.get("slot").map_or(0, |a| a.parse::<u8>().unwrap());
     let phys_part_idx = attrs
         .get("physical_partition_number")
         .unwrap()
@@ -74,7 +77,15 @@ fn parse_patch_cmd<T: Read + Write + QdlChan>(
     let start_sector = attrs.get("start_sector").unwrap();
     let val = attrs.get("value").unwrap();
 
-    firehose_patch(channel, byte_off, phys_part_idx, size, start_sector, val)
+    firehose_patch(
+        channel,
+        byte_off,
+        slot,
+        phys_part_idx,
+        size,
+        start_sector,
+        val,
+    )
 }
 
 const BOOTABLE_PART_NAMES: [&str; 3] = ["xbl", "xbl_a", "sbl1"];
@@ -104,6 +115,7 @@ fn parse_program_cmd<T: Read + Write + QdlChan>(
         .unwrap()
         .parse::<usize>()
         .unwrap();
+    let slot = attrs.get("slot").map_or(0, |a| a.parse::<u8>().unwrap());
     let phys_part_idx = attrs
         .get("physical_partition_number")
         .unwrap()
@@ -151,6 +163,7 @@ fn parse_program_cmd<T: Read + Write + QdlChan>(
         &mut buf,
         label,
         num_sectors,
+        slot,
         phys_part_idx,
         start_sector,
     )

--- a/qdl/src/lib.rs
+++ b/qdl/src/lib.rs
@@ -281,6 +281,7 @@ pub fn firehose_get_storage_info<T: Read + Write + QdlChan>(
 pub fn firehose_patch<T: Read + Write + QdlChan>(
     channel: &mut T,
     byte_off: u64,
+    slot: u8,
     phys_part_idx: u8,
     size: u64,
     start_sector: &str,
@@ -295,6 +296,7 @@ pub fn firehose_patch<T: Read + Write + QdlChan>(
             ),
             ("byte_offset", &byte_off.to_string()),
             ("filename", "DISK"), // DISK means "patch device's storage"
+            ("slot", &slot.to_string()),
             ("physical_partition_number", &phys_part_idx.to_string()),
             ("size_in_bytes", &size.to_string()),
             ("start_sector", start_sector),
@@ -359,6 +361,7 @@ pub fn firehose_program_storage<T: Read + Write + QdlChan>(
     data: &mut impl Read,
     label: &str,
     num_sectors: usize,
+    slot: u8,
     phys_part_idx: u8,
     start_sector: &str,
 ) -> anyhow::Result<()> {
@@ -371,6 +374,7 @@ pub fn firehose_program_storage<T: Read + Write + QdlChan>(
                 &channel.fh_config().storage_sector_size.to_string(),
             ),
             ("num_partition_sectors", &num_sectors.to_string()),
+            ("slot", &slot.to_string()),
             ("physical_partition_number", &phys_part_idx.to_string()),
             ("start_sector", start_sector),
             (
@@ -461,6 +465,7 @@ pub fn firehose_read_storage<T: Read + Write + QdlChan>(
     channel: &mut T,
     out: &mut impl Write,
     num_sectors: usize,
+    slot: u8,
     phys_part_idx: u8,
     start_sector: u32,
 ) -> anyhow::Result<()> {
@@ -473,6 +478,7 @@ pub fn firehose_read_storage<T: Read + Write + QdlChan>(
                 &channel.fh_config().storage_sector_size.to_string(),
             ),
             ("num_partition_sectors", &num_sectors.to_string()),
+            ("slot", &slot.to_string()),
             ("physical_partition_number", &phys_part_idx.to_string()),
             ("start_sector", &start_sector.to_string()),
         ],

--- a/qdl/src/types.rs
+++ b/qdl/src/types.rs
@@ -54,6 +54,7 @@ pub struct FirehoseConfiguration {
     pub xml_buf_size: usize,
 
     pub storage_sector_size: usize,
+    pub storage_slot: u8,
     pub storage_type: FirehoseStorageType,
 
     pub bypass_storage: bool,
@@ -73,6 +74,7 @@ impl Default for FirehoseConfiguration {
             recv_buffer_size: 4096,
             xml_buf_size: 4096,
             storage_sector_size: 512,
+            storage_slot: 0,
             storage_type: FirehoseStorageType::Emmc,
             bypass_storage: true,
             hash_packets: false,


### PR DESCRIPTION
Secondary (tertiary, etc.) devices of the same type are accessed by passing an additional "slot" tag, with the value being 0-indexed.

Add support for handling it in cli & in storage ops