### PR TITLE
qdl: types: Require Send + Sync for QdlReadWrite

### DIFF
--- a/qdl/src/types.rs
+++ b/qdl/src/types.rs
@@ -91,7 +91,7 @@ pub trait QdlChan {
     fn mut_fh_config(&mut self) -> &mut FirehoseConfiguration;
 }
 
-pub trait QdlReadWrite: Read + Write {}
+pub trait QdlReadWrite: Read + Write + Send + Sync {}
 
 pub struct QdlDevice<'a> {
     pub rw: &'a mut dyn QdlReadWrite,


### PR DESCRIPTION
Both back-ends have the thread safety plumbing in place, require it for our trait as well.