### PR TITLE
qdl: Remove unused storage_slot field from FirehoseConfiguration

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -231,7 +231,6 @@ fn main() -> Result<()> {
                     }
                 }
             },
-            storage_slot: args.storage_slot,
             bypass_storage: args.bypass_storage,
             backend,
             skip_firehose_log: !args.print_firehose_log,

--- a/qdl/src/types.rs
+++ b/qdl/src/types.rs
@@ -54,7 +54,6 @@ pub struct FirehoseConfiguration {
     pub xml_buf_size: usize,
 
     pub storage_sector_size: usize,
-    pub storage_slot: u8,
     pub storage_type: FirehoseStorageType,
 
     pub bypass_storage: bool,
@@ -74,7 +73,6 @@ impl Default for FirehoseConfiguration {
             recv_buffer_size: 4096,
             xml_buf_size: 4096,
             storage_sector_size: 512,
-            storage_slot: 0,
             storage_type: FirehoseStorageType::Emmc,
             bypass_storage: true,
             hash_packets: false,


### PR DESCRIPTION
It's thankfully not necessary, which means that multiple storage slots can be handled during a single Firehose session.