### PR TITLE
qdl: switch from anyhow to thiserror 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "crc",
  "nix",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -322,7 +322,6 @@ name = "qdl"
 version = "0.1.0"
 dependencies = [
  "anstream",
- "anyhow",
  "bincode",
  "indexmap",
  "owo-colors",
@@ -331,6 +330,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "serial2",
+ "thiserror 2.0.17",
  "xmltree",
 ]
 
@@ -449,7 +449,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -457,6 +466,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/programfile.rs
+++ b/cli/src/programfile.rs
@@ -34,7 +34,12 @@ fn parse_read_cmd<T: QdlChan>(
     let start_sector = attrs.get("start_sector").unwrap().parse::<u32>().unwrap();
 
     if checksum_only {
-        return firehose_checksum_storage(channel, num_sectors, phys_part_idx, start_sector);
+        return Ok(firehose_checksum_storage(
+            channel,
+            num_sectors,
+            phys_part_idx,
+            start_sector,
+        )?);
     }
 
     if !attrs.contains_key("filename") {
@@ -42,14 +47,14 @@ fn parse_read_cmd<T: QdlChan>(
     }
     let mut outfile = fs::File::create(out_dir.join(attrs.get("filename").unwrap()))?;
 
-    firehose_read_storage(
+    Ok(firehose_read_storage(
         channel,
         &mut outfile,
         num_sectors,
         slot,
         phys_part_idx,
         start_sector,
-    )
+    )?)
 }
 
 fn parse_patch_cmd<T: QdlChan>(
@@ -77,7 +82,7 @@ fn parse_patch_cmd<T: QdlChan>(
     let start_sector = attrs.get("start_sector").unwrap();
     let val = attrs.get("value").unwrap();
 
-    firehose_patch(
+    Ok(firehose_patch(
         channel,
         byte_off,
         slot,
@@ -85,7 +90,7 @@ fn parse_patch_cmd<T: QdlChan>(
         size,
         start_sector,
         val,
-    )
+    )?)
 }
 
 const BOOTABLE_PART_NAMES: [&str; 3] = ["xbl", "xbl_a", "sbl1"];
@@ -158,7 +163,7 @@ fn parse_program_cmd<T: QdlChan>(
         sector_size as i64 * file_sector_offset as i64,
     ))?;
 
-    firehose_program_storage(
+    Ok(firehose_program_storage(
         channel,
         &mut buf,
         label,
@@ -166,7 +171,7 @@ fn parse_program_cmd<T: QdlChan>(
         slot,
         phys_part_idx,
         start_sector,
-    )
+    )?)
 }
 
 // TODO: there's some funny optimizations to make here, such as OoO loading files into memory, or doing things while we're waiting on the device to finish

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -101,12 +101,12 @@ pub fn read_storage_logical_partition<T: QdlChan>(
         .ok_or(Error::from(ErrorKind::NotFound))?
         .1;
 
-    firehose_read_storage(
+    Ok(firehose_read_storage(
         channel,
         out,
         (part.ending_lba - part.starting_lba + 1) as usize,
         slot,
         phys_part_idx,
         part.starting_lba as u32,
-    )
+    )?)
 }

--- a/qdl/Cargo.toml
+++ b/qdl/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/lib.rs"
 
 [dependencies]
 anstream = "0.6.15"
-anyhow = "1.0"
 bincode = "1.3.3"
 indexmap = "2.5.0"
 owo-colors = "4.1.0"
@@ -28,6 +27,7 @@ rusb = { version = "0.9.4", optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_repr = "0.1.19"
 serial2 = { version = "0.2.28", optional = true }
+thiserror = "2.0.17"
 xmltree = { version = "0.11.0", features = ["attribute-order"] }
 
 [features]

--- a/qdl/src/serial.rs
+++ b/qdl/src/serial.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-use anyhow::{Result, bail};
 use serial2::{self, SerialPort};
 use std::io::{BufRead, Read, Write};
 
@@ -62,12 +61,8 @@ impl BufRead for QdlSerialConfig {
 
 impl QdlReadWrite for QdlSerialConfig {}
 
-pub fn setup_serial_device(dev_path: Option<String>) -> Result<QdlSerialConfig> {
-    if dev_path.is_none() {
-        bail!("Serial port path unspecified");
-    }
-
-    let serport = SerialPort::open(dev_path.unwrap(), |mut settings: serial2::Settings| {
+pub fn setup_serial_device(dev_path: String) -> Result<QdlSerialConfig, std::io::Error> {
+    let serport = SerialPort::open(dev_path, |mut settings: serial2::Settings| {
         settings.set_raw();
         settings.set_baud_rate(115200)?;
         Ok(settings)


### PR DESCRIPTION
This makes it possible for library users to match on errors.

Errors are also more descriptive now:

    Error: I/O error while reading
    
    Caused by:
       0: libusb error
       1: Overflow

Compared to what it was before:

    Error: other error

For some reasoning, see https://kazlauskas.me/entries/errors