### PR TITLE
fix(cli): skip non-DISK <patch> even when not verbose

### DIFF
--- a/cli/src/programfile.rs
+++ b/cli/src/programfile.rs
@@ -58,8 +58,10 @@ fn parse_patch_cmd<T: QdlChan>(
     verbose: bool,
 ) -> anyhow::Result<()> {
     if let Some(filename) = attrs.get("filename") {
-        if filename != "DISK" && verbose {
-            println!("Skipping <patch> tag trying to alter {filename} on Host filesystem");
+        if filename != "DISK" {
+            if verbose {
+                println!("Skipping <patch> tag trying to alter {filename} on Host filesystem");
+            }
             return Ok(());
         }
     } else {


### PR DESCRIPTION
## Background

The CLI currently skips `<patch>` entries with `filename != "DISK"` **only when `--verbose` is enabled**.
When `--verbose` is disabled (the default), those patches are still applied.

This makes the actual flashing behavior depend on a logging/debug flag, which is unintended and
can lead to inconsistent results when flashing the same package with different verbosity settings.

## Problem

With the existing logic:

- `filename != "DISK" && verbose == true` → patch is skipped
- `filename != "DISK" && verbose == false` → patch is applied

As a result, enabling or disabling `--verbose` changes the set of patches that are executed.
This is especially problematic for GPT / partition patching, where applying or skipping a patch
can affect device bootability.

## Change

This PR makes the behavior consistent and deterministic:

- `<patch>` entries with `filename != "DISK"` are **always skipped**
- `--verbose` now controls **logging only**, not execution logic

In other words, the skip condition no longer depends on the verbosity flag.

## Rationale

`--verbose` should never alter flashing semantics.
Decoupling logging from execution makes the CLI behavior predictable and safer for automated
and production flashing workflows.

## Impact

- No behavior change for users who already ran with `--verbose`
- Removes a class of hard-to-debug issues where the same command behaves differently depending
  on verbosity