### PR TITLE
qdl: Handle Sahara multi-image programmer archives

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,7 +11,7 @@ use qdl::types::{FirehoseResetMode, FirehoseStorageType, QdlBackend, QdlDevice};
 use qdl::{firehose_configure, firehose_read, firehose_reset, types::FirehoseConfiguration};
 use qdl::{
     firehose_get_default_sector_size, firehose_nop, firehose_peek, firehose_program_storage,
-    firehose_set_bootable, setup_target_device,
+    firehose_set_bootable, load_programmer_images, setup_target_device,
 };
 use util::{
     find_part, print_partition_table, read_gpt_from_storage, read_storage_logical_partition,
@@ -197,7 +197,7 @@ fn main() -> Result<()> {
     let reset_mode = FirehoseResetMode::from_str(&args.reset_mode)?;
 
     // Get the MBN loader binary
-    let mbn_loader = match fs::read(args.loader_path) {
+    let mut mbn_loader = match load_programmer_images(&args.loader_path) {
         Ok(m) => m,
         Err(e) => bail!("Couldn't open the programmer binary: {}", e.to_string()),
     };
@@ -277,7 +277,7 @@ fn main() -> Result<()> {
         &mut qdl_dev,
         SaharaMode::WaitingForImage,
         None,
-        &mut [mbn_loader],
+        &mut mbn_loader,
         vec![],
         args.verbose_sahara,
     )?;

--- a/qdl/src/lib.rs
+++ b/qdl/src/lib.rs
@@ -85,13 +85,8 @@ pub fn firehose_read<T: QdlChan>(
             Err(e) => match e.kind() {
                 // In some cases (like with welcome messages), there's no acking
                 // and a timeout is the "end of data" marker instead..
-                std::io::ErrorKind::TimedOut => {
-                    if got_any_data {
-                        return Ok(FirehoseStatus::Ack);
-                    } else {
-                        return Err(e.into());
-                    }
-                }
+                std::io::ErrorKind::TimedOut if got_any_data => return Ok(FirehoseStatus::Ack),
+                std::io::ErrorKind::TimedOut => return Err(e.into()),
                 _ => return Err(e.into()),
             },
         };

--- a/qdl/src/lib.rs
+++ b/qdl/src/lib.rs
@@ -2,11 +2,14 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 use anstream::println;
 use anyhow::Result;
-use indexmap::IndexMap;
+use indexmap::{Equivalent, IndexMap};
 use owo_colors::OwoColorize;
 use parsers::firehose_parser_ack_nak;
+use serde::{Deserialize, Serialize};
 use std::cmp::min;
+use std::fs;
 use std::io::{Read, Write};
+use std::path::Path;
 use std::str::{self, FromStr};
 use types::FirehoseResetMode;
 use types::FirehoseStatus;
@@ -26,6 +29,132 @@ pub mod serial;
 pub mod types;
 #[cfg(feature = "usb")]
 pub mod usb;
+
+pub const SAHARA_ID_EHOSTDL_IMG: usize = 13;
+
+const CPIO_MAGIC: &[u8; 6] = b"070701";
+
+#[repr(C)]
+#[derive(Debug, Serialize, Deserialize)]
+struct CpioNewcHeader {
+    c_magic: [u8; 6],
+    c_ino: [u8; 8],
+    c_mode: [u8; 8],
+    c_uid: [u8; 8],
+    c_gid: [u8; 8],
+    c_nlink: [u8; 8],
+    c_mtime: [u8; 8],
+    c_filesize: [u8; 8],
+    c_devmajor: [u8; 8],
+    c_devminor: [u8; 8],
+    c_rdevmajor: [u8; 8],
+    c_rdevminor: [u8; 8],
+    c_namesize: [u8; 8],
+    c_check: [u8; 8],
+}
+
+fn align_up_4(n: usize) -> usize {
+    (n + 3) & !3
+}
+
+fn parse_ascii_hex_u32(field: &[u8]) -> Result<u32> {
+    let s = std::str::from_utf8(field)?;
+    if s.len() != 8 {
+        bail!("invalid cpio header field size");
+    }
+
+    u32::from_str_radix(s, 16).map_err(|_| anyhow::anyhow!("invalid hex field \"{}\"", s))
+}
+
+fn decode_programmer_archive(blob: &[u8], images: &mut Vec<Option<Vec<u8>>>) -> Result<bool> {
+    if blob.len() < size_of::<CpioNewcHeader>() || &blob[..6] != CPIO_MAGIC {
+        return Ok(false);
+    }
+
+    let mut ptr = 0usize;
+
+    loop {
+        if ptr + size_of::<CpioNewcHeader>() > blob.len() {
+            bail!("programmer archive is truncated");
+        }
+
+        let hdr =
+            bincode::deserialize::<CpioNewcHeader>(&blob[ptr..ptr + size_of::<CpioNewcHeader>()])?;
+        if !hdr.c_magic.equivalent(CPIO_MAGIC) {
+            bail!("expected cpio header in programmer archive");
+        }
+
+        let filesize = parse_ascii_hex_u32(&hdr.c_filesize)? as usize;
+        let namesize = parse_ascii_hex_u32(&hdr.c_namesize)? as usize;
+
+        ptr += size_of::<CpioNewcHeader>();
+        if ptr + namesize > blob.len() {
+            bail!("programmer archive is truncated");
+        }
+
+        if namesize == 0 {
+            bail!("missing filename in programmer archive entry");
+        }
+
+        let name_raw = &blob[ptr..ptr + namesize];
+        let name_end = name_raw
+            .iter()
+            .position(|b| *b == 0)
+            .unwrap_or(name_raw.len());
+        let name = std::str::from_utf8(&name_raw[..name_end])
+            .map_err(|_| anyhow::anyhow!("invalid utf8 in programmer archive filename"))?;
+
+        if name == "TRAILER!!!" {
+            break;
+        }
+
+        let id_str = name.split(':').next().unwrap_or("");
+        if id_str.is_empty() {
+            bail!("missing image id in programmer archive entry");
+        }
+
+        let id = id_str
+            .parse::<u32>()
+            .map_err(|_| anyhow::anyhow!("invalid decimal image id \"{}\"", id_str))?;
+        if id == 0 {
+            bail!("invalid image id \"{}\" in programmer archive", id_str);
+        }
+
+        ptr += namesize;
+        ptr = align_up_4(ptr);
+        if ptr + filesize > blob.len() {
+            bail!("programmer archive is truncated");
+        }
+
+        let file_data = &blob[ptr..ptr + filesize];
+        if id as usize >= images.len() {
+            images.resize(id as usize + 1, None);
+        }
+        images[id as usize] = Some(file_data.to_vec());
+
+        ptr += filesize;
+        ptr = align_up_4(ptr);
+    }
+
+    Ok(true)
+}
+
+/// Load Sahara programmer image(s) from disk.
+///
+/// If `path` points to a CPIO `newc` archive, this decodes entries named like
+/// `<id>:<name>` (or just `<id>`) and stores each file in its Sahara image slot.
+/// Otherwise, the file is returned as a single-slot image list, preserving
+/// legacy single-image Sahara behavior.
+pub fn load_programmer_images(path: impl AsRef<Path>) -> Result<Vec<Option<Vec<u8>>>> {
+    let blob = fs::read(path.as_ref())?;
+    let mut images: Vec<Option<Vec<u8>>> = Vec::new();
+
+    if decode_programmer_archive(&blob, &mut images)? {
+        return Ok(images);
+    }
+
+    Ok(vec![Some(blob)])
+}
 
 pub fn setup_target_device(
     backend: QdlBackend,

--- a/qdl/src/sahara.rs
+++ b/qdl/src/sahara.rs
@@ -219,13 +219,15 @@ pub struct RamdumpTable64 {
 
 pub fn sahara_send_img_to_device<T: Read + Write>(
     channel: &mut T,
-    img_arr: &mut [Vec<u8>],
+    img_arr: &mut [Option<Vec<u8>>],
     image_idx: u64,
     image_offset: u64,
     image_len: u64,
 ) -> Result<usize, anyhow::Error> {
     let image = if img_arr.len() == 1 { 0 } else { image_idx };
-    let buf = &mut img_arr[image as usize];
+    let Some(Some(buf)) = img_arr.get(image as usize) else {
+        bail!("Sahara requested missing image ID {}", image_idx,);
+    };
     if (image_offset + image_len) as usize > buf.len() {
         bail!(
             "Attempted OOB read {} > {}",
@@ -480,7 +482,7 @@ pub fn sahara_run<T: QdlChan>(
     channel: &mut T,
     sahara_mode: SaharaMode,
     sahara_command: Option<SaharaCmdModeCmd>,
-    images: &mut [Vec<u8>],
+    images: &mut [Option<Vec<u8>>],
     filenames: Vec<String>,
     verbose: bool,
 ) -> Result<Vec<u8>> {


### PR DESCRIPTION
Some targets do not provide a single Sahara programmer blob. Instead, the programmer payload is delivered as multiple images that must be selected by Sahara image ID, so loading one file and passing it directly to sahara_run() fails on those devices.

Add a qdl helper that loads programmer input from disk and first attempts to decode it as a CPIO newc archive whose entries are named as <id>:<name>, mapping each entry to the corresponding Sahara image slot. The archive decoder now grows the image vector dynamically to fit the highest requested image ID, removing the fixed SAHARA_IMAGE_MAPPING_SIZE limitation. When the input is not an archive, keep existing behavior by treating it as a single programmer blob and placing it in SAHARA_ID_EHOSTDL_IMG (13).

Wire qdl-rs CLI to use this loader and pass the full image map to sahara_run(). Also make sahara_send_img_to_device() return a clear error when a requested image ID is missing instead of panicking on out-of-bounds access.